### PR TITLE
fix: Repair value undefined from causing problems.

### DIFF
--- a/packages/up-provider/src/server.ts
+++ b/packages/up-provider/src/server.ts
@@ -849,7 +849,7 @@ function createUPProviderConnector(provider?: any, rpcUrls?: string | string[]):
                   channel_.emit('sentTransaction', {
                     from: request.params[0]?.from,
                     to: request.params[0]?.to,
-                    value: request.params[0]?.value,
+                    value: request.params[0]?.value || BigInt(0),
                     result: response.result,
                     error: response.error,
                   })


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug
A value of undefined in valid in JSON-RPC but not for the event payload.
